### PR TITLE
Add sharp for image builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/node": "25.9.3",
     "astro": "6.4.8",
     "oxfmt": "0.55.0",
+    "sharp": "0.35.1",
     "typescript": "6.0.3",
     "wrangler": "4.102.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       oxfmt:
         specifier: 0.55.0
         version: 0.55.0
+      sharp:
+        specifier: 0.35.1
+        version: 0.35.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- add sharp as an explicit dev dependency for Astro image generation
- fixes CI deploy build failing with MissingSharp on a fresh install

## Validation
- pnpm install --frozen-lockfile
- pnpm audit
- pnpm check
- pnpm build