### PR TITLE
Update web app manifest

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,8 +1,22 @@
 {
   "name": "Carter McBride",
-  "short_name": "Carter McBride",
+  "short_name": "Carter",
+  "description": "A developer from Utah.",
   "start_url": "/",
-  "icons": [],
-  "background_color": "#fdf6e3",
-  "display": "standalone"
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f1f1f1",
+  "theme_color": "#f1f1f1",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,7 @@ const fediverseCreator = "@literallyacar@mastodon.social";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="theme-color" content="#f1f1f1" />


### PR DESCRIPTION
## Summary
- refresh the web app manifest metadata to match the current homepage and theme
- add existing favicon and Apple touch icon assets to the manifest
- link the manifest from the base layout

## Checks
- \Finished in 322ms on 41 files using 10 threads.
- \16:41:36 [vite] Re-optimizing dependencies because vite config has changed
16:41:36 [content] Syncing content
16:41:36 [content] Synced content
16:41:36 [types] Generated 357ms
16:41:36 [check] Getting diagnostics for Astro files in /Users/cmcbride/homebase/code/github.com/carterworks/site...
Result (20 files): 
- 0 errors
- 0 warnings
- 0 hints