### PR TITLE
Add Twitter card metadata

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ const ogImage = metadata?.ogImage
   ? new URL(metadata.ogImage, Astro.site)
   : undefined;
 const fediverseCreator = "@literallyacar@mastodon.social";
+const socialTitle = metadata?.ogTitle ?? title;
 ---
 
 <!doctype html>
@@ -47,7 +48,7 @@ const fediverseCreator = "@literallyacar@mastodon.social";
         <meta name="description" content={metadata.description} />
       )
     }
-    {metadata && <meta property="og:title" content={metadata.title} />}
+    {metadata && <meta property="og:title" content={socialTitle} />}
     {
       metadata?.description && (
         <meta property="og:description" content={metadata.description} />
@@ -58,7 +59,16 @@ const fediverseCreator = "@literallyacar@mastodon.social";
     {ogImage && <meta property="og:image:type" content="image/webp" />}
     {ogImage && <meta property="og:image:width" content="1200" />}
     {ogImage && <meta property="og:image:height" content="630" />}
-    {metadata && <meta property="og:image:alt" content={metadata.title} />}
+    {metadata && <meta property="og:image:alt" content={socialTitle} />}
+    {metadata && <meta name="twitter:card" content="summary_large_image" />}
+    {metadata && <meta name="twitter:title" content={socialTitle} />}
+    {
+      metadata?.description && (
+        <meta name="twitter:description" content={metadata.description} />
+      )
+    }
+    {ogImage && <meta name="twitter:image" content={ogImage} />}
+    {ogImage && <meta name="twitter:image:alt" content={socialTitle} />}
     <style is:global>
       @layer reset {
         *,


### PR DESCRIPTION
## Summary

- Add Twitter Card metadata for link previews
- Reuse existing social metadata titles for Open Graph and Twitter tags
- Include Twitter image and image alt tags when an Open Graph image exists

## Testing

- pnpm format
- pnpm check
- pnpm build