### PR TITLE
Improve Pages CMS publishing workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: package.json
           cache: pnpm
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,17 @@ name: Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      payload:
+        description: Pages CMS payload as JSON
+        required: false
+        type: string
   push:
     branches:
       - main
+
+env:
+  CI: true
 
 jobs:
   deploy:
@@ -18,10 +26,11 @@ jobs:
           node-version: 24
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
       - name: Build
         run: pnpm run build
       - name: Deploy
+        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/pages-cms-media.yml
+++ b/.github/workflows/pages-cms-media.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: package.json
           cache: pnpm
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/pages-cms-media.yml
+++ b/.github/workflows/pages-cms-media.yml
@@ -1,0 +1,71 @@
+name: Pages CMS Media
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: Pages CMS payload as JSON
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CI: true
+
+concurrency:
+  group: pages-cms-media-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  optimize:
+    runs-on: ubuntu-latest
+    name: Optimize media
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Optimize assets
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --silent assets public/assets --out=same | tee generated-assets.txt
+      - name: Generate image markup
+        shell: bash
+        run: |
+          if [ -s generated-assets.txt ]; then
+            pnpm --silent media:markup $(cat generated-assets.txt) | tee media-markup.html
+          else
+            : > media-markup.html
+          fi
+
+          {
+            printf '## Generated image markup\n\n'
+            if [ -s media-markup.html ]; then
+              printf '```html\n'
+              cat media-markup.html
+              printf '\n```\n'
+            else
+              printf 'No image markup generated.\n'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Commit optimized assets
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/assets
+          if git diff --cached --quiet; then
+            printf 'No optimized asset changes to commit.\n'
+          else
+            git commit -m "Optimize CMS media"
+            git push
+          fi

--- a/.pages.yml
+++ b/.pages.yml
@@ -18,12 +18,14 @@ content:
     type: collection
     path: content/blog
     format: yaml-frontmatter
-    filename: "{year}-{month}-{day}-{primary}.md"
+    filename:
+      template: "{year}-{month}-{day}-{title}.md"
+      field: create
     exclude:
       - assets/**
     view:
-      fields: [title, pubDate, draft]
-      primary: title
+      fields: [pubDate, title, description, draft]
+      primary: pubDate
       sort: [pubDate, title]
       default:
         sort: pubDate
@@ -32,13 +34,21 @@ content:
       - name: title
         label: Title
         type: string
+        required: false
+      - name: description
+        label: Description
+        type: text
+        required: false
       - name: pubDate
         label: Publication date
         type: date
         required: true
+        options:
+          format: yyyy-MM-dd
       - name: draft
         label: Draft
         type: boolean
+        default: false
       - name: body
         label: Body
         type: rich-text

--- a/.pages.yml
+++ b/.pages.yml
@@ -1,16 +1,11 @@
 media:
-  - name: blog_assets
-    label: Blog assets
+  - name: assets
+    label: Assets
     input: public/assets
     output: /assets
     rename: safe
-    categories: [image]
-  - name: public_assets
-    label: Public assets
-    input: public/assets
-    output: /assets
-    rename: safe
-    categories: [image, video, audio]
+    categories: [image, video]
+    extensions: [avif, jpg, jpeg, png, webp, m4v, mov, mp4, webm]
     actions:
       - name: optimize-media
         label: Optimize media
@@ -29,6 +24,7 @@ content:
       field: create
     exclude:
       - assets/**
+      - _*.md
     view:
       fields: [pubDate, title, description, draft]
       primary: pubDate
@@ -56,7 +52,7 @@ content:
         type: boolean
         default: false
       - name: body
-        label: Body
+        label: Markdown / HTML
         type: code
         options:
           format: markdown

--- a/.pages.yml
+++ b/.pages.yml
@@ -57,3 +57,10 @@ content:
 settings:
   content:
     merge: true
+
+actions:
+  - name: deploy-site
+    label: Deploy site
+    workflow: deploy.yml
+    ref: current
+    cancelable: false

--- a/.pages.yml
+++ b/.pages.yml
@@ -11,6 +11,12 @@ media:
     output: /assets
     rename: safe
     categories: [image, video, audio]
+    actions:
+      - name: optimize-media
+        label: Optimize media
+        workflow: pages-cms-media.yml
+        ref: current
+        cancelable: false
 
 content:
   - name: blog

--- a/.pages.yml
+++ b/.pages.yml
@@ -51,11 +51,9 @@ content:
         default: false
       - name: body
         label: Body
-        type: rich-text
+        type: code
         options:
           format: markdown
-          media: blog_assets
-          switcher: true
 settings:
   content:
     merge: true

--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@
 
 # Blog post format
 
-Blog posts are `/content/blog/*.md`. They are `[slug].md`. `title`, `pubDate`, and `description` are required frontmatter fields. `pubDate` is a string in the format `YYYY-MM-DD`. The `<time is="formatted-date"/>` component is used to format the date in the post.
+Blog posts are `/content/blog/*.md`. They are `[slug].md`. `pubDate` is required frontmatter in the format `YYYY-MM-DD`. `title` and `description` are optional. Posts without a title derive one from the first non-empty line of the body.
 
 ```md
 ---
 title: "Hello world!"
 pubDate: 2024-01-02
 description: "Why are there so many hello world posts and not more hello country posts? Start small, dummy."
-tags:
-  - writing
-  - placeholder
+draft: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eleifend mi in nulla posuere sollicitudin aliquam ultrices. Luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor. Suspendisse in est ante in nibh. Eros in cursus turpis massa tincidunt dui ut ornare. Porta lorem mollis aliquam ut porttitor leo. Eu volutpat odio facilisis mauris sit amet massa vitae. Amet nisl purus in mollis nunc sed id semper. Consequat id porta nibh venenatis cras sed felis. Purus faucibus ornare suspendisse sed nisi lacus sed. Maecenas volutpat blandit aliquam etiam erat velit scelerisque in. Penatibus et magnis dis parturient montes nascetur ridiculus mus. Lacus luctus accumsan tortor posuere. At auctor urna nunc id cursus. Risus nullam eget felis eget nunc lobortis mattis. Fringilla phasellus faucibus scelerisque eleifend. Imperdiet nulla malesuada pellentesque elit eget. Orci nulla pellentesque dignissim enim sit amet. Pellentesque diam volutpat commodo sed egestas.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "assets": "node scripts/assets.mjs",
+    "media:markup": "node scripts/media-markup.mjs",
     "cf-typegen": "wrangler types",
     "format": "oxfmt --write .",
     "check": "astro check && tsc --noEmit",

--- a/scripts/media-markup.mjs
+++ b/scripts/media-markup.mjs
@@ -5,16 +5,34 @@ import sharp from "sharp";
 const defaultInput = "public/assets";
 const imageExtensions = new Set([".avif", ".jpeg", ".jpg", ".png", ".webp"]);
 
+/** @typedef {{ file: string, height: number, width: number }} ImageVariant */
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 const toPosix = (value) => value.split(path.sep).join("/");
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 const escapeAttribute = (value) =>
   value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
 
+/**
+ * @param {string} file
+ * @returns {string}
+ */
 const publicPath = (file) => {
   const relative = toPosix(path.relative("public", file));
   return relative.startsWith("..") ? toPosix(file) : `/${relative}`;
 };
 
+/**
+ * @param {string} input
+ * @returns {Promise<string[]>}
+ */
 const collect = async (input) => {
   const inputPath = path.resolve(input);
   const inputStat = await stat(inputPath);
@@ -30,12 +48,20 @@ const collect = async (input) => {
   return files;
 };
 
+/**
+ * @param {string} file
+ * @returns {string}
+ */
 const groupKey = (file) => {
   const extension = path.extname(file).toLowerCase();
   const basename = path.basename(file, extension);
   return path.join(path.dirname(file), basename.replace(/-\d+$/, ""));
 };
 
+/**
+ * @param {string} file
+ * @returns {Promise<ImageVariant>}
+ */
 const image = async (file) => {
   const metadata = await sharp(file).metadata();
   if (!metadata.width || !metadata.height) {
@@ -44,6 +70,10 @@ const image = async (file) => {
   return { file, height: metadata.height, width: metadata.width };
 };
 
+/**
+ * @param {ImageVariant[]} variants
+ * @returns {string}
+ */
 const markup = (variants) => {
   const sorted = variants.toSorted((a, b) => a.width - b.width);
   const largest = sorted.at(-1);
@@ -74,7 +104,9 @@ const markup = (variants) => {
 const inputs = process.argv.slice(2);
 const files = [
   ...new Set(
-    (await Promise.all((inputs.length ? inputs : [defaultInput]).map(collect))).flat(),
+    (
+      await Promise.all((inputs.length ? inputs : [defaultInput]).map(collect))
+    ).flat(),
   ),
 ];
 const groups = Map.groupBy(files, groupKey);

--- a/scripts/media-markup.mjs
+++ b/scripts/media-markup.mjs
@@ -1,0 +1,88 @@
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import sharp from "sharp";
+
+const defaultInput = "public/assets";
+const imageExtensions = new Set([".avif", ".jpeg", ".jpg", ".png", ".webp"]);
+
+const toPosix = (value) => value.split(path.sep).join("/");
+
+const escapeAttribute = (value) =>
+  value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+
+const publicPath = (file) => {
+  const relative = toPosix(path.relative("public", file));
+  return relative.startsWith("..") ? toPosix(file) : `/${relative}`;
+};
+
+const collect = async (input) => {
+  const inputPath = path.resolve(input);
+  const inputStat = await stat(inputPath);
+
+  if (inputStat.isFile()) {
+    return imageExtensions.has(path.extname(inputPath)) ? [inputPath] : [];
+  }
+
+  const files = [];
+  for (const entry of await readdir(inputPath, { withFileTypes: true })) {
+    files.push(...(await collect(path.join(inputPath, entry.name))));
+  }
+  return files;
+};
+
+const groupKey = (file) => {
+  const extension = path.extname(file).toLowerCase();
+  const basename = path.basename(file, extension);
+  return path.join(path.dirname(file), basename.replace(/-\d+$/, ""));
+};
+
+const image = async (file) => {
+  const metadata = await sharp(file).metadata();
+  if (!metadata.width || !metadata.height) {
+    throw new Error(`Could not read image size: ${file}`);
+  }
+  return { file, height: metadata.height, width: metadata.width };
+};
+
+const markup = (variants) => {
+  const sorted = variants.toSorted((a, b) => a.width - b.width);
+  const largest = sorted.at(-1);
+  const attributes = [`src="${escapeAttribute(publicPath(largest.file))}"`];
+
+  if (sorted.length > 1) {
+    attributes.push(
+      `srcset="${escapeAttribute(
+        sorted
+          .map((variant) => `${publicPath(variant.file)} ${variant.width}w`)
+          .join(", "),
+      )}"`,
+      `sizes="(max-width: ${largest.width}px) 100vw, ${largest.width}px"`,
+    );
+  }
+
+  attributes.push(
+    'alt=""',
+    `width="${largest.width}"`,
+    `height="${largest.height}"`,
+    'loading="lazy"',
+    'decoding="async"',
+  );
+
+  return `<img ${attributes.join(" ")}>`;
+};
+
+const inputs = process.argv.slice(2);
+const files = [
+  ...new Set(
+    (await Promise.all((inputs.length ? inputs : [defaultInput]).map(collect))).flat(),
+  ),
+];
+const groups = Map.groupBy(files, groupKey);
+
+const snippets = await Promise.all(
+  [...groups.values()].map(async (files) =>
+    markup(await Promise.all(files.map(image))),
+  ),
+);
+
+console.log(snippets.sort().join("\n\n"));

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,7 +12,7 @@ const blogPostLabel =
 const mostRecentBlogPost = posts[0];
 ---
 
-<BaseLayout>
+<BaseLayout class="stack">
   <Fragment slot="head">
     <style>
       ol {


### PR DESCRIPTION
## Summary

- Update Pages CMS blog config for optional titles/descriptions, title-less posts, and raw Markdown/HTML editing.
- Add Pages CMS actions for deploying the site and optimizing uploaded media.
- Add a media markup helper that generates copy-paste `<img>` tags with `srcset`, dimensions, lazy loading, and async decoding.
- Tighten media config to one image/video asset source and hide underscore-prefixed templates from the CMS.
- Apply the stack layout class to the blog index layout.

## Testing

- `pnpm check`
- `pnpm --silent media:markup public/assets/samdape-the-creation-of-projects-600.avif public/assets/samdape-the-creation-of-projects-1000.avif`