### PR TITLE
Keep page position when opening command bar

### DIFF
--- a/src/components/command-bar.test.ts
+++ b/src/components/command-bar.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import "./command-bar";
 
 const markup = `
@@ -86,14 +86,6 @@ describe("command bar", () => {
         "accesskey",
       ),
     ).toBe("k");
-  });
-
-  test("scrolls to the top before opening", () => {
-    const scrollTo = vi.spyOn(window, "scrollTo");
-
-    getElement<HTMLInputElement>(".command-trigger").click();
-
-    expect(scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
   test("filters commands by every search word and reports an empty result", () => {

--- a/src/components/command-bar.ts
+++ b/src/components/command-bar.ts
@@ -159,7 +159,6 @@ class CommandBarElement extends HTMLElement {
 
     const prepare = () => {
       if (dialog.matches(":popover-open")) return;
-      window.scrollTo(0, 0);
       rebuildPageLinks();
       updateSchemeLabel();
       dialog.showPopover();


### PR DESCRIPTION
## Summary

- stop the command bar from scrolling the page to the top when it opens
- remove the obsolete scroll behavior test

## Testing

- `nub run format`
- `nub run test -- src/components/command-bar.test.ts`
- `nub run check`